### PR TITLE
Update aws_c_http_jq_jll to version 0.9.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTPFork"
 uuid = "d3f1d20b-921e-4930-8491-471e0be3121a"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_137
+    union (unnamed at /home/runner/.julia/artifacts/f9dedab34619ae5a428ad6b01820ae0c799d09ca/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_137
+struct var"union (unnamed at /home/runner/.julia/artifacts/f9dedab34619ae5a428ad6b01820ae0c799d09ca/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_137}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f9dedab34619ae5a428ad6b01820ae0c799d09ca/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_137, f::Symbol)
-    r = Ref{__JL_Ctag_137}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_137}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f9dedab34619ae5a428ad6b01820ae0c799d09ca/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f9dedab34619ae5a428ad6b01820ae0c799d09ca/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f9dedab34619ae5a428ad6b01820ae0c799d09ca/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_137}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f9dedab34619ae5a428ad6b01820ae0c799d09ca/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_137}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f9dedab34619ae5a428ad6b01820ae0c799d09ca/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_371
+    union (unnamed at /home/runner/.julia/artifacts/65af1968bbd7a892db4b5ded49050138c05b8108/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_371
+struct var"union (unnamed at /home/runner/.julia/artifacts/65af1968bbd7a892db4b5ded49050138c05b8108/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_371}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65af1968bbd7a892db4b5ded49050138c05b8108/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_371, f::Symbol)
-    r = Ref{__JL_Ctag_371}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_371}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/65af1968bbd7a892db4b5ded49050138c05b8108/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/65af1968bbd7a892db4b5ded49050138c05b8108/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65af1968bbd7a892db4b5ded49050138c05b8108/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_371}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65af1968bbd7a892db4b5ded49050138c05b8108/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_371}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65af1968bbd7a892db4b5ded49050138c05b8108/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_155
+    union (unnamed at /home/runner/.julia/artifacts/c6a67851f04f3928916565cc94d7a529a11e8455/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_155
+struct var"union (unnamed at /home/runner/.julia/artifacts/c6a67851f04f3928916565cc94d7a529a11e8455/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_155}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c6a67851f04f3928916565cc94d7a529a11e8455/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_155, f::Symbol)
-    r = Ref{__JL_Ctag_155}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_155}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c6a67851f04f3928916565cc94d7a529a11e8455/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c6a67851f04f3928916565cc94d7a529a11e8455/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c6a67851f04f3928916565cc94d7a529a11e8455/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_155}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c6a67851f04f3928916565cc94d7a529a11e8455/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_155}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c6a67851f04f3928916565cc94d7a529a11e8455/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_371
+    union (unnamed at /home/runner/.julia/artifacts/c4e36330261cd30321d981c8f7aac04d80d71bec/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_371
+struct var"union (unnamed at /home/runner/.julia/artifacts/c4e36330261cd30321d981c8f7aac04d80d71bec/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_371}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c4e36330261cd30321d981c8f7aac04d80d71bec/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_371, f::Symbol)
-    r = Ref{__JL_Ctag_371}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_371}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c4e36330261cd30321d981c8f7aac04d80d71bec/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c4e36330261cd30321d981c8f7aac04d80d71bec/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c4e36330261cd30321d981c8f7aac04d80d71bec/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_371}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c4e36330261cd30321d981c8f7aac04d80d71bec/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_371}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c4e36330261cd30321d981c8f7aac04d80d71bec/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_155
+    union (unnamed at /home/runner/.julia/artifacts/d807a8aec3deaae3eaf6fc52d5750a105bf705ab/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_155
+struct var"union (unnamed at /home/runner/.julia/artifacts/d807a8aec3deaae3eaf6fc52d5750a105bf705ab/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_155}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d807a8aec3deaae3eaf6fc52d5750a105bf705ab/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_155, f::Symbol)
-    r = Ref{__JL_Ctag_155}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_155}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d807a8aec3deaae3eaf6fc52d5750a105bf705ab/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d807a8aec3deaae3eaf6fc52d5750a105bf705ab/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d807a8aec3deaae3eaf6fc52d5750a105bf705ab/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_155}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d807a8aec3deaae3eaf6fc52d5750a105bf705ab/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_155}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d807a8aec3deaae3eaf6fc52d5750a105bf705ab/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_362
+    union (unnamed at /home/runner/.julia/artifacts/eb53f31c0d533ceaf05473221d793d7f38309092/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_362
+struct var"union (unnamed at /home/runner/.julia/artifacts/eb53f31c0d533ceaf05473221d793d7f38309092/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_362}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/eb53f31c0d533ceaf05473221d793d7f38309092/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_362, f::Symbol)
-    r = Ref{__JL_Ctag_362}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_362}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/eb53f31c0d533ceaf05473221d793d7f38309092/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/eb53f31c0d533ceaf05473221d793d7f38309092/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/eb53f31c0d533ceaf05473221d793d7f38309092/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_362}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/eb53f31c0d533ceaf05473221d793d7f38309092/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_362}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/eb53f31c0d533ceaf05473221d793d7f38309092/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_155
+    union (unnamed at /home/runner/.julia/artifacts/87d6d26a539b8ed8e976935fe52a1ef70c68b3bb/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_155
+struct var"union (unnamed at /home/runner/.julia/artifacts/87d6d26a539b8ed8e976935fe52a1ef70c68b3bb/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_155}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/87d6d26a539b8ed8e976935fe52a1ef70c68b3bb/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_155, f::Symbol)
-    r = Ref{__JL_Ctag_155}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_155}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/87d6d26a539b8ed8e976935fe52a1ef70c68b3bb/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/87d6d26a539b8ed8e976935fe52a1ef70c68b3bb/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/87d6d26a539b8ed8e976935fe52a1ef70c68b3bb/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_155}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/87d6d26a539b8ed8e976935fe52a1ef70c68b3bb/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_155}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/87d6d26a539b8ed8e976935fe52a1ef70c68b3bb/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_362
+    union (unnamed at /home/runner/.julia/artifacts/2b3be0306fa91698c79632499167cdb08aeeee07/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_362
+struct var"union (unnamed at /home/runner/.julia/artifacts/2b3be0306fa91698c79632499167cdb08aeeee07/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_362}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2b3be0306fa91698c79632499167cdb08aeeee07/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_362, f::Symbol)
-    r = Ref{__JL_Ctag_362}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_362}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2b3be0306fa91698c79632499167cdb08aeeee07/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2b3be0306fa91698c79632499167cdb08aeeee07/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2b3be0306fa91698c79632499167cdb08aeeee07/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_362}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2b3be0306fa91698c79632499167cdb08aeeee07/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_362}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2b3be0306fa91698c79632499167cdb08aeeee07/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_362
+    union (unnamed at /home/runner/.julia/artifacts/ca3ba3e112df2341cbee49482b270925ab683df1/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_362
+struct var"union (unnamed at /home/runner/.julia/artifacts/ca3ba3e112df2341cbee49482b270925ab683df1/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_362}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ca3ba3e112df2341cbee49482b270925ab683df1/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_362, f::Symbol)
-    r = Ref{__JL_Ctag_362}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_362}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ca3ba3e112df2341cbee49482b270925ab683df1/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ca3ba3e112df2341cbee49482b270925ab683df1/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ca3ba3e112df2341cbee49482b270925ab683df1/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_362}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ca3ba3e112df2341cbee49482b270925ab683df1/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_362}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ca3ba3e112df2341cbee49482b270925ab683df1/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_155
+    union (unnamed at /home/runner/.julia/artifacts/d73b2af52134cd87d1fca3c76e3ceeeb2341deb6/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_155
+struct var"union (unnamed at /home/runner/.julia/artifacts/d73b2af52134cd87d1fca3c76e3ceeeb2341deb6/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_155}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d73b2af52134cd87d1fca3c76e3ceeeb2341deb6/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_155, f::Symbol)
-    r = Ref{__JL_Ctag_155}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_155}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d73b2af52134cd87d1fca3c76e3ceeeb2341deb6/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d73b2af52134cd87d1fca3c76e3ceeeb2341deb6/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d73b2af52134cd87d1fca3c76e3ceeeb2341deb6/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_155}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d73b2af52134cd87d1fca3c76e3ceeeb2341deb6/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_155}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d73b2af52134cd87d1fca3c76e3ceeeb2341deb6/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_119
+    union (unnamed at /home/runner/.julia/artifacts/7c48cab296700626a746dc1e55e509eeda727e9a/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_119
+struct var"union (unnamed at /home/runner/.julia/artifacts/7c48cab296700626a746dc1e55e509eeda727e9a/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_119}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c48cab296700626a746dc1e55e509eeda727e9a/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_119, f::Symbol)
-    r = Ref{__JL_Ctag_119}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_119}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7c48cab296700626a746dc1e55e509eeda727e9a/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7c48cab296700626a746dc1e55e509eeda727e9a/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c48cab296700626a746dc1e55e509eeda727e9a/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_119}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c48cab296700626a746dc1e55e509eeda727e9a/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_119}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c48cab296700626a746dc1e55e509eeda727e9a/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -651,6 +652,8 @@ struct aws_http_connection_manager_options
     shutdown_complete_callback::Ptr{aws_http_connection_manager_shutdown_complete_fn}
     enable_read_back_pressure::Bool
     max_connection_idle_in_milliseconds::UInt64
+    connection_acquisition_timeout_ms::UInt64
+    max_pending_connection_acquisitions::UInt64
     network_interface_names_array::Ptr{aws_byte_cursor}
     num_network_interface_names::Csize_t
 end
@@ -785,6 +788,8 @@ Documentation not found.
     AWS_ERROR_HTTP_MANUAL_WRITE_NOT_ENABLED = 2090
     AWS_ERROR_HTTP_MANUAL_WRITE_HAS_COMPLETED = 2091
     AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT = 2092
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_ACQUISITION_TIMEOUT = 2093
+    AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED = 2094
     AWS_ERROR_HTTP_END_RANGE = 3071
 end
 
@@ -1193,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_101
+    union (unnamed at /home/runner/.julia/artifacts/d0f8a16f97a5073fc79bda6517c2d03edba2efe7/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_101
+struct var"union (unnamed at /home/runner/.julia/artifacts/d0f8a16f97a5073fc79bda6517c2d03edba2efe7/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_101}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d0f8a16f97a5073fc79bda6517c2d03edba2efe7/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_101, f::Symbol)
-    r = Ref{__JL_Ctag_101}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_101}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d0f8a16f97a5073fc79bda6517c2d03edba2efe7/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d0f8a16f97a5073fc79bda6517c2d03edba2efe7/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d0f8a16f97a5073fc79bda6517c2d03edba2efe7/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_101}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d0f8a16f97a5073fc79bda6517c2d03edba2efe7/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1230,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_101}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d0f8a16f97a5073fc79bda6517c2d03edba2efe7/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1698,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1733,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2622,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 
@@ -3445,6 +3448,20 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
+"""
+    aws_websocket_server_upgrade_options
+
+Documentation not found.
+"""
+struct aws_websocket_server_upgrade_options
+    initial_window_size::Csize_t
+    user_data::Ptr{Cvoid}
+    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
+    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
+    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
+    manual_window_management::Bool
+end
+
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3643,6 +3660,50 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
+end
+
+"""
+    aws_websocket_is_websocket_request(request)
+
+Return true if the request is a valid websocket upgrade request.
+
+### Prototype
+```c
+bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
+```
+"""
+function aws_websocket_is_websocket_request(request)
+    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
+end
+
+"""
+    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+
+Create response with all required fields for a websocket upgrade response. The following headers are added:
+
+Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
+
+### Prototype
+```c
+struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
+```
+"""
+function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
+    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
+end
+
+"""
+    aws_websocket_upgrade(allocator, stream, options)
+
+Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
+
+### Prototype
+```c
+struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
+```
+"""
+function aws_websocket_upgrade(allocator, stream, options)
+    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jq_jll** to version **0.9.5**
- Updated **JuliaServices/LibAwsHTTPFork.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings