### PR TITLE
Update aws_c_http_jq_jll to version 0.9.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTPFork"
 uuid = "d3f1d20b-921e-4930-8491-471e0be3121a"
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jq_jll** to version **0.9.7**
- Updated **JuliaServices/LibAwsHTTPFork.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings