### PR TITLE
Update aws_c_http_jq_jll to version 0.10.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTPFork"
 uuid = "d3f1d20b-921e-4930-8491-471e0be3121a"
-version = "1.0.4"
+version = "1.0.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jq_jll = "=0.9.8"
+aws_c_http_jq_jll = "=0.10.1"
 julia = "1.6"
 
 [extras]

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/a1726f49d1eb59d841d583d5c32e0c89f1f5fa91/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a1726f49d1eb59d841d583d5c32e0c89f1f5fa91/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a1726f49d1eb59d841d583d5c32e0c89f1f5fa91/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a1726f49d1eb59d841d583d5c32e0c89f1f5fa91/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a1726f49d1eb59d841d583d5c32e0c89f1f5fa91/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a1726f49d1eb59d841d583d5c32e0c89f1f5fa91/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a1726f49d1eb59d841d583d5c32e0c89f1f5fa91/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a1726f49d1eb59d841d583d5c32e0c89f1f5fa91/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/c69e05430e010aa9980e01774fd723b0bb937a9e/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c69e05430e010aa9980e01774fd723b0bb937a9e/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c69e05430e010aa9980e01774fd723b0bb937a9e/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c69e05430e010aa9980e01774fd723b0bb937a9e/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c69e05430e010aa9980e01774fd723b0bb937a9e/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c69e05430e010aa9980e01774fd723b0bb937a9e/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c69e05430e010aa9980e01774fd723b0bb937a9e/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c69e05430e010aa9980e01774fd723b0bb937a9e/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/7ebb0064554272a7f74e663c812b1a7d667c2bc4/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/7ebb0064554272a7f74e663c812b1a7d667c2bc4/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7ebb0064554272a7f74e663c812b1a7d667c2bc4/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7ebb0064554272a7f74e663c812b1a7d667c2bc4/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7ebb0064554272a7f74e663c812b1a7d667c2bc4/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7ebb0064554272a7f74e663c812b1a7d667c2bc4/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7ebb0064554272a7f74e663c812b1a7d667c2bc4/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7ebb0064554272a7f74e663c812b1a7d667c2bc4/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/8bb51d9857e084222e74d70ab7606d2f7c7012f0/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/8bb51d9857e084222e74d70ab7606d2f7c7012f0/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8bb51d9857e084222e74d70ab7606d2f7c7012f0/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8bb51d9857e084222e74d70ab7606d2f7c7012f0/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8bb51d9857e084222e74d70ab7606d2f7c7012f0/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8bb51d9857e084222e74d70ab7606d2f7c7012f0/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8bb51d9857e084222e74d70ab7606d2f7c7012f0/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8bb51d9857e084222e74d70ab7606d2f7c7012f0/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/7836238c5fe442efb7fb330aa635c87ab7243620/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/7836238c5fe442efb7fb330aa635c87ab7243620/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7836238c5fe442efb7fb330aa635c87ab7243620/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7836238c5fe442efb7fb330aa635c87ab7243620/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7836238c5fe442efb7fb330aa635c87ab7243620/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7836238c5fe442efb7fb330aa635c87ab7243620/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7836238c5fe442efb7fb330aa635c87ab7243620/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7836238c5fe442efb7fb330aa635c87ab7243620/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/4ad2b48ab3155caec442577e9faf3520a448d339/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/4ad2b48ab3155caec442577e9faf3520a448d339/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ad2b48ab3155caec442577e9faf3520a448d339/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/4ad2b48ab3155caec442577e9faf3520a448d339/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/4ad2b48ab3155caec442577e9faf3520a448d339/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ad2b48ab3155caec442577e9faf3520a448d339/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ad2b48ab3155caec442577e9faf3520a448d339/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ad2b48ab3155caec442577e9faf3520a448d339/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/415b1bf7281c97a1a65f1a1d516fe97399ad08c1/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/415b1bf7281c97a1a65f1a1d516fe97399ad08c1/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/415b1bf7281c97a1a65f1a1d516fe97399ad08c1/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/415b1bf7281c97a1a65f1a1d516fe97399ad08c1/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/415b1bf7281c97a1a65f1a1d516fe97399ad08c1/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/415b1bf7281c97a1a65f1a1d516fe97399ad08c1/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/415b1bf7281c97a1a65f1a1d516fe97399ad08c1/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/415b1bf7281c97a1a65f1a1d516fe97399ad08c1/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/6073662f50021a4710098544a22b69ff507088e9/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6073662f50021a4710098544a22b69ff507088e9/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6073662f50021a4710098544a22b69ff507088e9/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6073662f50021a4710098544a22b69ff507088e9/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6073662f50021a4710098544a22b69ff507088e9/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6073662f50021a4710098544a22b69ff507088e9/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6073662f50021a4710098544a22b69ff507088e9/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6073662f50021a4710098544a22b69ff507088e9/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/3a8b5de49c79a098c07299c6e9c5f4d47019b945/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/3a8b5de49c79a098c07299c6e9c5f4d47019b945/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3a8b5de49c79a098c07299c6e9c5f4d47019b945/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3a8b5de49c79a098c07299c6e9c5f4d47019b945/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3a8b5de49c79a098c07299c6e9c5f4d47019b945/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3a8b5de49c79a098c07299c6e9c5f4d47019b945/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3a8b5de49c79a098c07299c6e9c5f4d47019b945/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3a8b5de49c79a098c07299c6e9c5f4d47019b945/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/dca67c167def529fd841d0defc3ae83bd2ffc01b/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/dca67c167def529fd841d0defc3ae83bd2ffc01b/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dca67c167def529fd841d0defc3ae83bd2ffc01b/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/dca67c167def529fd841d0defc3ae83bd2ffc01b/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/dca67c167def529fd841d0defc3ae83bd2ffc01b/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dca67c167def529fd841d0defc3ae83bd2ffc01b/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dca67c167def529fd841d0defc3ae83bd2ffc01b/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dca67c167def529fd841d0defc3ae83bd2ffc01b/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/f2a51be0e5c348df7fca7fecb6524e43262b6820/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/f2a51be0e5c348df7fca7fecb6524e43262b6820/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f2a51be0e5c348df7fca7fecb6524e43262b6820/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f2a51be0e5c348df7fca7fecb6524e43262b6820/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f2a51be0e5c348df7fca7fecb6524e43262b6820/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f2a51be0e5c348df7fca7fecb6524e43262b6820/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f2a51be0e5c348df7fca7fecb6524e43262b6820/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f2a51be0e5c348df7fca7fecb6524e43262b6820/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/a78c9cb5f5e7df7460037ae907432b79db71fbe5/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a78c9cb5f5e7df7460037ae907432b79db71fbe5/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a78c9cb5f5e7df7460037ae907432b79db71fbe5/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a78c9cb5f5e7df7460037ae907432b79db71fbe5/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a78c9cb5f5e7df7460037ae907432b79db71fbe5/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a78c9cb5f5e7df7460037ae907432b79db71fbe5/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a78c9cb5f5e7df7460037ae907432b79db71fbe5/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a78c9cb5f5e7df7460037ae907432b79db71fbe5/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2941,6 +2946,8 @@ If the connection was created with `manual_window_management` set true, the flow
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
 
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
+
 ### Prototype
 ```c
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);
@@ -3448,20 +3455,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3660,50 +3653,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jq_jll** to version **0.10.1**
- Updated **JuliaServices/LibAwsHTTPFork.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings