### PR TITLE
Update aws_c_http_jq_jll to version 0.10.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTPFork"
 uuid = "d3f1d20b-921e-4930-8491-471e0be3121a"
-version = "1.0.4"
+version = "1.0.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jq_jll = "=0.9.8"
+aws_c_http_jq_jll = "=0.10.2"
 julia = "1.6"
 
 [extras]

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dcbf6df3f3caedaddc5b6babfde533b9631ca87/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cb5b99a1d1e52a9a0e431915199b52f680336d0/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e8bfc179990302d61713ac41f40f4d3cca4f9865/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/635c0c62979f87dc4d1e4f4b4d2fe7a51b43d020/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5c1c1a85ef2520c88ee0011d7a307705c542046/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5dd832698b99af95e1f833d725e6138a67264120/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/294cf221bad5c09e61594687be051eb9687772de/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/294cf221bad5c09e61594687be051eb9687772de/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/294cf221bad5c09e61594687be051eb9687772de/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/294cf221bad5c09e61594687be051eb9687772de/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/294cf221bad5c09e61594687be051eb9687772de/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/294cf221bad5c09e61594687be051eb9687772de/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/294cf221bad5c09e61594687be051eb9687772de/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/294cf221bad5c09e61594687be051eb9687772de/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/de4009bb3e8e54134efc77a8c5683acad31fc018/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7c620a9e3e4b06a8da5dd78c8954196d75f896bd/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e315637f3e62d46167707ae715bf607f256430a7/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e0e3648df52697b7b538df4a633962ba3aafdd05/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81a44777851125d836920060d8a0d72d169bc82e/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138782f1a6cd5adbdc6c2084251c7b444b056fe8/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jq_jll** to version **0.10.2**
- Updated **JuliaServices/LibAwsHTTPFork.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings