### PR TITLE
Update aws_c_http_jq_jll to version 0.10.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTPFork"
 uuid = "d3f1d20b-921e-4930-8491-471e0be3121a"
-version = "1.0.5"
+version = "1.0.6"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -11,14 +11,15 @@ LibAwsIO = "a5388770-19df-4151-b103-3d71de896ddf"
 aws_c_http_jq_jll = "8f53af78-0b28-57f6-844a-4720ec1bfefc"
 
 [compat]
-Aqua = "0.7"
+Aqua = "0.7,0.8"
 CEnum = "0.5"
 LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jq_jll = "=0.10.2"
+aws_c_http_jq_jll = "=0.10.6"
 julia = "1.6"
+Test = "1.11"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0a9f325bb7385a853365ca0bbfb154614c702981/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7fb02f8455840f59ecec47ebdfbbdb29308f4801/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13089f5158c2a073c2b7a53e2d5efc08c77137c7/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/61d47862bf8bc1057aba53312a13cd3ea75c2196/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2c077327ce2e523ddf64f5b47678b73465d93655/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c380614d5e23d524c7ad69a0ce51c483b45cbbf2/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb057971ae84be10d9bbe1a7ddfe32ea100b8797/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1fd61db125a84a127c616cb4beb648862e93c03/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f5c506eb4c21b2534e5e61718d938ee44d7d1443/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7305bc0465f36a7b6109b23c7cedd066769c46/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a032f2a2906cef92b0164d8756be4ae5627adf3c/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/46690f84325782abaf207923b9f5f6c1ae7423fd/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a608a0bc43e40d0340e8f05272bc220e21ad70fa/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -3455,20 +3456,6 @@ struct aws_websocket_client_connection_options
     host_resolution_config::Ptr{aws_host_resolution_config}
 end
 
-"""
-    aws_websocket_server_upgrade_options
-
-Documentation not found.
-"""
-struct aws_websocket_server_upgrade_options
-    initial_window_size::Csize_t
-    user_data::Ptr{Cvoid}
-    on_incoming_frame_begin::Ptr{aws_websocket_on_incoming_frame_begin_fn}
-    on_incoming_frame_payload::Ptr{aws_websocket_on_incoming_frame_payload_fn}
-    on_incoming_frame_complete::Ptr{aws_websocket_on_incoming_frame_complete_fn}
-    manual_window_management::Bool
-end
-
 # typedef bool ( aws_websocket_stream_outgoing_payload_fn ) ( struct aws_websocket * websocket , struct aws_byte_buf * out_buf , void * user_data )
 """
 Called repeatedly as the websocket's payload is streamed out. The user should write payload data to out\\_buf, up to available capacity. The websocket will mask this data for you, if necessary. Invoked repeatedly on the websocket's event-loop thread.
@@ -3667,50 +3654,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request( struc
 """
 function aws_http_message_new_websocket_handshake_request(allocator, path, host)
     ccall((:aws_http_message_new_websocket_handshake_request, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor, aws_byte_cursor), allocator, path, host)
-end
-
-"""
-    aws_websocket_is_websocket_request(request)
-
-Return true if the request is a valid websocket upgrade request.
-
-### Prototype
-```c
-bool aws_websocket_is_websocket_request(const struct aws_http_message *request);
-```
-"""
-function aws_websocket_is_websocket_request(request)
-    ccall((:aws_websocket_is_websocket_request, libaws_c_http_jq), Bool, (Ptr{aws_http_message},), request)
-end
-
-"""
-    aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-
-Create response with all required fields for a websocket upgrade response. The following headers are added:
-
-Upgrade: websocket Connection: Upgrade Sec-WebSocket-Accept: <base64 encoded accept key>
-
-### Prototype
-```c
-struct aws_http_message *aws_http_message_new_websocket_handshake_response( struct aws_allocator *allocator, struct aws_byte_cursor accept_key);
-```
-"""
-function aws_http_message_new_websocket_handshake_response(allocator, accept_key)
-    ccall((:aws_http_message_new_websocket_handshake_response, libaws_c_http_jq), Ptr{aws_http_message}, (Ptr{aws_allocator}, aws_byte_cursor), allocator, accept_key)
-end
-
-"""
-    aws_websocket_upgrade(allocator, stream, options)
-
-Upgrade an incoming HTTP connection to a websocket connection. This function should be called from the on\\_request\\_done callback of a request handler. It expects a fully constructed request and will handle sending the handshake response and install the websocket handler into the channel.
-
-### Prototype
-```c
-struct aws_websocket *aws_websocket_upgrade( struct aws_allocator *allocator, struct aws_http_stream *stream, const struct aws_websocket_server_upgrade_options *options);
-```
-"""
-function aws_websocket_upgrade(allocator, stream, options)
-    ccall((:aws_websocket_upgrade, libaws_c_http_jq), Ptr{aws_websocket}, (Ptr{aws_allocator}, Ptr{aws_http_stream}, Ptr{aws_websocket_server_upgrade_options}), allocator, stream, options)
 end
 
 """


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jq_jll** to version **0.10.6**
- Updated **JuliaServices/LibAwsHTTPFork.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings