### PR TITLE
Update aws_c_http_jq_jll to version 0.10.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTPFork"
 uuid = "d3f1d20b-921e-4930-8491-471e0be3121a"
-version = "1.0.6"
+version = "1.0.7"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jq_jll = "=0.10.6"
+aws_c_http_jq_jll = "=0.10.8"
 julia = "1.6"
 Test = "1.11"
 

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_38
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_38
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_38}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_38, f::Symbol)
+    r = Ref{__JL_Ctag_38}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_38}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_38}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_38, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7462356ce6118e7f75f705b89b1ae23564fddadc/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_38}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,32 +1204,6 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)
-
-Documentation not found.
-"""
-struct var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"
-    data::NTuple{8, UInt8}
-end
-
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}, f::Symbol)
-    f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
-    f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
-"""
     aws_http_proxy_negotiator
 
 Documentation not found.
@@ -1241,7 +1215,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/72321f4919c0bf1edfd7e8e62c651e45e8a1400a/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_182}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1228,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2424,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2445,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2459,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2473,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2487,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2501,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2515,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2529,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2543,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2557,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2571,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2585,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2599,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2613,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbcd9fea1a17e8ea72a64a5faa3f9b0ecbe52e0/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,32 +1204,6 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)
-
-Documentation not found.
-"""
-struct var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"
-    data::NTuple{4, UInt8}
-end
-
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}, f::Symbol)
-    f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
-    f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
-"""
     aws_http_proxy_negotiator
 
 Documentation not found.
@@ -1241,7 +1215,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a9848e880812b56aa3e4d8c66a728db0c3982faa/include/aws/http/proxy.h:310:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_182}(x + 16)
     return getfield(x, f)
 end
 
@@ -1254,6 +1228,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2424,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2445,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2459,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2473,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2487,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2501,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2515,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2529,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2543,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2557,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2571,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2585,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2599,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2613,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/31839854613f4013fbc05c340b7ba53adf547133/include/aws/http/proxy.h:310:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 16)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_173
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_173
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_173}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_173, f::Symbol)
+    r = Ref{__JL_Ctag_173}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_173}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_173}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_173, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd2b9facd76374134196421e5b59cd9ea2a63411/include/aws/http/proxy.h:310:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_173}(x + 16)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d5e3a62de4e41310f1f1d538492bda10b2a3035/include/aws/http/proxy.h:310:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 16)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_173
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_173
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_173}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_173, f::Symbol)
+    r = Ref{__JL_Ctag_173}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_173}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_173}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_173, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c71abb465052c59db9db52b1af0e2cc235f6b274/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_173}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_38
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_38
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_38}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_38, f::Symbol)
+    r = Ref{__JL_Ctag_38}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_38}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_38}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_38, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d11ec9c8043d0ecb7448b222ece57fdcc531ed4/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_38}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_164
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_164
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_164}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_164, f::Symbol)
+    r = Ref{__JL_Ctag_164}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_164}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_164}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_164, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b31b227f1fc78622c2fc9a73430ce121c15043b6/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_164}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a5883dfcc7d780ab48d734e9f43d548a4a937006/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8be25ce6e830ee34ddae452f606137d606305a9/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -1204,29 +1204,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1249,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3b7300c7e9fe43ca5e48368e5a507dba1875d87a/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1262,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2458,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2479,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2493,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2507,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2521,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2535,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2549,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2563,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2577,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2591,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2605,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2619,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2633,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2647,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jq_jll** to version **0.10.8**
- Updated **JuliaServices/LibAwsHTTPFork.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings